### PR TITLE
Adding in sponsors/sponserlevels backend and frontend

### DIFF
--- a/app/Http/Controllers/Api/SponsorLevelsController.php
+++ b/app/Http/Controllers/Api/SponsorLevelsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SoutheastPhp\Http\Controllers\Api;
+
+use Illuminate\Http\Response;
+use SoutheastPhp\Http\Controllers\Controller;
+use SoutheastPhp\Models\SponsorLevel;
+use SoutheastPhp\Transformers\Api\SponsorLevelTransformer;
+
+class SponsorLevelsController extends Controller
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @var SponsorLevelTransformer
+     */
+    private $transformer;
+
+    /**
+     * SponsorsController constructor.
+     * @param Response $response
+     * @param SponsorLevelTransformer $transformer
+     */
+    public function __construct(Response $response, SponsorLevelTransformer $transformer)
+    {
+        $this->response = $response;
+        $this->transformer = $transformer;
+    }
+
+    public function index()
+    {
+        $sponsors = SponsorLevel::all();
+
+        return $this->response->setStatusCode(200)->setContent(fractal($sponsors, $this->transformer)->toArray());
+    }
+}

--- a/app/Http/Controllers/Api/SponsorsController.php
+++ b/app/Http/Controllers/Api/SponsorsController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SoutheastPhp\Http\Controllers\Api;
+
+use Illuminate\Http\Response;
+use SoutheastPhp\Http\Controllers\Controller;
+use SoutheastPhp\Models\Sponsor;
+use SoutheastPhp\Transformers\Api\SponsorTransformer;
+
+class SponsorsController extends Controller
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @var SponsorTransformer
+     */
+    private $transformer;
+
+    /**
+     * SponsorsController constructor.
+     * @param Response $response
+     * @param SponsorTransformer $transformer
+     */
+    public function __construct(Response $response, SponsorTransformer $transformer)
+    {
+        $this->response = $response;
+        $this->transformer = $transformer;
+    }
+
+    public function index()
+    {
+        $sponsors = Sponsor::all();
+
+        return $this->response->setStatusCode(200)->setContent(fractal($sponsors, $this->transformer)->toArray());
+    }
+
+    public function levels()
+    {
+
+    }
+}

--- a/app/Http/Controllers/Api/SponsorsController.php
+++ b/app/Http/Controllers/Api/SponsorsController.php
@@ -36,9 +36,4 @@ class SponsorsController extends Controller
 
         return $this->response->setStatusCode(200)->setContent(fractal($sponsors, $this->transformer)->toArray());
     }
-
-    public function levels()
-    {
-
-    }
 }

--- a/app/Models/Sponsor.php
+++ b/app/Models/Sponsor.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SoutheastPhp\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Sponsor extends Model
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSponsorLevel()
+    {
+        return $this->belongsTo(SponsorLevel::class, 'sponsor_level', 'id');
+    }
+
+    /**
+     * @return string
+     */
+    public function getWebsite(): string
+    {
+        return $this->website;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAbout(): string
+    {
+        return $this->about;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImage(): string
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTwitter(): string
+    {
+        return $this->twitter;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFacebook(): string
+    {
+        return $this->facebook;
+    }
+}

--- a/app/Models/SponsorLevel.php
+++ b/app/Models/SponsorLevel.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SoutheastPhp\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SponsorLevel extends Model
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRemaining(): int
+    {
+        return $this->remaining;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInformation(): string
+    {
+        return $this->information;
+    }
+}

--- a/app/Transformers/Api/SponsorLevelTransformer.php
+++ b/app/Transformers/Api/SponsorLevelTransformer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SoutheastPhp\Transformers\Api;
+
+use League\Fractal\TransformerAbstract;
+use SoutheastPhp\Models\SponsorLevel;
+
+class SponsorLevelTransformer extends TransformerAbstract
+{
+    public function transform(SponsorLevel $sponsorLevel)
+    {
+        return [
+            'name' => $sponsorLevel->getName(),
+            'information' => $sponsorLevel->getInformation(),
+            'remaining' => $sponsorLevel->getRemaining()
+        ];
+    }
+}

--- a/app/Transformers/Api/SponsorTransformer.php
+++ b/app/Transformers/Api/SponsorTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SoutheastPhp\Transformers\Api;
+
+use League\Fractal\TransformerAbstract;
+use SoutheastPhp\Models\Sponsor;
+
+class SponsorTransformer extends TransformerAbstract
+{
+    public function transform(Sponsor $sponsor)
+    {
+        return [
+            'name' => $sponsor->getName(),
+            'website' => $sponsor->getWebsite(),
+            'image' => $sponsor->getImage(),
+            'sponsorLevel' => $sponsor->getSponsorLevel->name,
+            'about' => $sponsor->getAbout(),
+            'twitter' => $sponsor->getTwitter(),
+            'facebook' => $sponsor->getFacebook(),
+        ];
+    }
+}

--- a/database/migrations/2017_10_14_172638_create_sponsors_table.php
+++ b/database/migrations/2017_10_14_172638_create_sponsors_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSponsorsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sponsor_levels', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('remaining');
+            $table->text('information');
+            $table->timestamps();
+        });
+
+        Schema::create('sponsors', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('sponsor_level');
+            $table->string('website');
+            $table->text('about')->nullable();
+            $table->string('image')->nullable();
+            $table->string('twitter')->nullable();
+            $table->string('facebook')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sponsors');
+        Schema::dropIfExists('sponsor_levels');
+    }
+}

--- a/resources/assets/js/components/sponsors.vue
+++ b/resources/assets/js/components/sponsors.vue
@@ -1,0 +1,135 @@
+<style lang='scss' scoped>
+    .container  {
+        padding-top: 7rem;
+    }
+
+    .cfp {
+        font-size: 5rem;
+    }
+
+    .links {
+        a {
+            color: #000;
+        }
+
+        a:hover {
+            color: #c0c0c0;
+        }
+    }
+
+    .sponsor-image {
+        display: block;
+        margin: 10px auto;
+        border-radius: 6px;
+    }
+
+    p.sponsor-metadata {
+        text-align:center;
+    }
+</style>
+<template>
+    <div>
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-12">
+                    <h1>Our Sponsors</h1>
+                </div>
+                <div class="col-xs-12" v-if="loading == false && (sponsorLevels.data.length == 0 || sponsors.data.length == 0)">
+                    <h2>No sponsors at this time, please check back later.</h2>
+                </div>
+                <div v-for="sponsorLevel in sponsorLevels.data">
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <h2>{{sponsorLevel.name}}</h2>
+                        </div>
+                    </div>
+                    <div v-if="sponsorsByLevel(sponsorLevel.name).length > 0">
+                        <div class="col-xs-12 col-md-4" v-for="sponsor in sponsorsByLevel(sponsorLevel.name)">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <img :src="sponsor.image" class="sponsor-image" :alt="sponsor.name">
+                                </div>
+                                <div class="panel-body">
+                                    <p>{{sponsor.about}}</p>
+                                    <p class="sponsor-metadata">
+                                        <a :href="sponsor.twitter"><i class="fa fa-twitter" v-if="sponsor.twitter" area-hidden="true"></i></a>
+                                        <a :href="sponsor.facebook"><i class="fa fa-facebook" v-if="sponsor.facebook" area-hidden="true"></i></a>
+                                        <a :href="sponsor.website"><i class="fa fa-id-card" v-if="sponsor.website" area-hidden="true"></i></a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-xs-12" v-else>
+                        <h3>No sponsors at this level yet.</h3>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-xs-12">
+                    <h1>Our Sponsor Levels</h1>
+                </div>
+
+                <table class="table table-hover">
+                    <thead>
+                    <tr>
+                        <th>Sponsor Level</th>
+                        <th>Spots Remaining</th>
+                        <th>Information</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="sponsorLevel in sponsorLevels.data">
+                        <td>{{sponsorLevel.name}}</td>
+                        <td>{{sponsorLevel.remaining}}</td>
+                        <td>{{sponsorLevel.information}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</template>
+<script>
+    import axios from 'axios';
+
+    export default {
+        data() {
+            return {
+                loading: true,
+                sponsorLevels: [],
+                sponsors: [],
+            };
+        },
+
+        created() {
+            axios.all([this.getSponsorLevels(), this.getSponsors()]).then(axios.spread((sponsorLevels, sponsors) => {
+                this.sponsorLevels = sponsorLevels;
+                this.sponsors = sponsors;
+                this.loading = false;
+            }));
+        },
+        methods: {
+            sponsorsByLevel(level) {
+                return this.sponsors.data.filter((sponsor) => {
+                    return sponsor.sponsorLevel == level;
+                });
+            },
+            getSponsorLevels() {
+                return axios.get('/api/sponsors/levels').then(response => {
+                    return response.data;
+                }, function (e) {
+                    console.log(e);
+                })
+            },
+            getSponsors() {
+                return axios.get('/api/sponsors').then(response => {
+                    return response.data;
+                }, function (e) {
+                    console.log(e);
+                })
+            }
+        }
+    };
+</script>

--- a/resources/assets/js/routes.js
+++ b/resources/assets/js/routes.js
@@ -5,6 +5,7 @@ import CodeOfConduct from './components/code-of-conduct.vue';
 import CocReport from './components/report.vue';
 import Nashville from './components/nashville.vue';
 import Speakers from './components/speakers.vue';
+import Sponsors from './components/sponsors.vue';
 import EmailSignups from './components/admin/signups.vue';
 
 const routes = [
@@ -37,6 +38,11 @@ const routes = [
     path: '/speakers',
     component: Speakers,
     name: 'Speakers',
+  },
+  {
+      path: '/sponsors',
+      component: Sponsors,
+      name: 'Sponsors',
   },
   {
     path: '/admin/emails',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -39,6 +39,7 @@
                 <ul class="nav navbar-nav">
                     <li><a href="/#/about">About</a></li>
                     <li><a href="/#/nashville">Nashville</a></li>
+                    <li><a href="/#/sponsors">Sponsors</a></li>
                     <li><a href="/#/code-of-conduct">Code of Conduct</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,3 +25,9 @@ Route::get('nashville', ['uses' => 'Api\NashvilleController@index']);
  * Organizers Routes
  */
 Route::get('organizers', ['uses' => 'Api\OrganizersController@index']);
+
+/**
+ * Sponsor Routes
+ */
+Route::get('sponsors', ['uses' => 'Api\SponsorsController@index']);
+Route::get('sponsors/levels', ['uses' => 'Api\SponsorLevelsController@index']);


### PR DESCRIPTION
Screenshots:

![2017-10-14-183032_1235x867_scrot](https://user-images.githubusercontent.com/518239/31580180-ee119d6a-b10d-11e7-9637-8d332260e2c2.png)

![2017-10-14-183043_1364x618_scrot](https://user-images.githubusercontent.com/518239/31580179-ebb0d6bc-b10d-11e7-9b17-9a1b566cd19d.png)

In order for the sponsors page to work correctly there must be both sponsor and sponsorLevel entities. The vue route loads both resources and uses it to display each filtered sponsor in the appropriate sponsorLevel section. The sponsor information section could use some more TLC such as a list group in Bootstrap 4 but that upgrading the css framework is out of scope of this PR.

Any feedback would be appreciated.